### PR TITLE
Added python 2 + 3 support

### DIFF
--- a/ics/component.py
+++ b/ics/component.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals, absolute_import
 
 from six import StringIO, string_types, text_type, integer_types
+import six
 
 import warnings
 from collections import namedtuple
@@ -84,11 +85,11 @@ class Component(object):
         return fn
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
-
-    def __unicode__(self):
         """Returns the component in an iCalendar format."""
         container = self._unused.clone()
         for output in self._OUTPUTS:
             output(self, container)
-        return unicode(container)
+        if six.PY2:
+            return text_type(container).encode('utf-8')
+        else:
+            return text_type(container)

--- a/ics/icalendar.py
+++ b/ics/icalendar.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals, absolute_import
 
 from six import StringIO, string_types, text_type, integer_types
+import six
 
 from dateutil.tz import tzical
 import copy
@@ -91,8 +92,10 @@ class Calendar(Component):
             >>> c = Calendar(); c.append(Event(name="My cool event"))
             >>> open('my.ics', 'w').writelines(c)
         """
-        for line in unicode(self).split(u'\n'):
-            l = (line + u'\n').encode('utf-8')
+        for line in text_type(self).split(u'\n'):
+            l = (line + u'\n')
+            if six.PY2:
+                l = l.encode('utf-8')
             yield l
 
     def __eq__(self, other):
@@ -246,10 +249,10 @@ def o_method(calendar, container):
 @Calendar._outputs
 def o_events(calendar, container):
     for event in calendar.events:
-        container.append(unicode(event))
+        container.append(text_type(event))
 
 
 @Calendar._outputs
 def o_todos(calendar, container):
     for todo in calendar.todos:
-        container.append(unicode(todo))
+        container.append(text_type(todo))

--- a/ics/parse.py
+++ b/ics/parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals, absolute_import
-
+import six
 import collections
 
 CRLF = u'\r\n'
@@ -36,14 +36,14 @@ class ContentLine:
         self.value = value
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
-
-    def __unicode__(self):
         params_str = ''
         for pname in self.params:
             params_str += u';{}={}'.format(pname, ','.join(self.params[pname]))
         ret = u"{}{}:{}".format(self.name, params_str, self.value)
-        return ret
+        if six.PY2:
+            return ret.encode('utf-8')
+        else:
+            return ret
 
     def __repr__(self):
         return "<ContentLine '{}' with {} parameter{}. Value='{}'>" \
@@ -99,15 +99,15 @@ class Container(list):
         self.name = name
 
     def __str__(self):
-        return __unicode__(self).encode('utf-8')
-
-    def __unicode__(self):
         name = self.name
         ret = [u'BEGIN:' + name]
         for line in self:
-            ret.append(unicode(line))
+            ret.append(six.text_type(line))
         ret.append(u'END:' + name)
-        return CRLF.join(ret)
+        if six.PY2:
+            return six.text_type(CRLF.join(ret)).encode('utf-8')
+        else:
+            return six.text_type(CRLF.join(ret))
 
     def __repr__(self):
         return "<Container '{}' with {} element{}>" \


### PR DESCRIPTION
@brettbond 
This was... confusing. I've tried to rewrite it without using if six.PY2 conditionals, and just using best practices for 2+3 support; After chasing for a few hours, realized that it's not worth it, and just built on top of your changes. Tested it on local schools build with py2, export works; Ran test suite on ics package with python 3.6, all tests passed, assume will work on schools py3 as well.