### PR TITLE
Fixed inconsistent str to unicode conversions to match previous version

### DIFF
--- a/ics/component.py
+++ b/ics/component.py
@@ -85,11 +85,14 @@ class Component(object):
         return fn
 
     def __str__(self):
+        if six.PY2:
+            return unicode(self).encode('utf-8')
+        else:
+            return self.__unicode__()
+
+    def __unicode__(self):
         """Returns the component in an iCalendar format."""
         container = self._unused.clone()
         for output in self._OUTPUTS:
             output(self, container)
-        if six.PY2:
-            return text_type(container).encode('utf-8')
-        else:
-            return text_type(container)
+        return text_type(container)

--- a/ics/parse.py
+++ b/ics/parse.py
@@ -36,14 +36,17 @@ class ContentLine:
         self.value = value
 
     def __str__(self):
+        if six.PY2:
+            return unicode(self).encode('utf-8')
+        else:
+            return self.__unicode__()
+
+    def __unicode__(self):
         params_str = ''
         for pname in self.params:
             params_str += u';{}={}'.format(pname, ','.join(self.params[pname]))
         ret = u"{}{}:{}".format(self.name, params_str, self.value)
-        if six.PY2:
-            return ret.encode('utf-8')
-        else:
-            return ret
+        return ret
 
     def __repr__(self):
         return "<ContentLine '{}' with {} parameter{}. Value='{}'>" \
@@ -99,15 +102,18 @@ class Container(list):
         self.name = name
 
     def __str__(self):
+        if six.PY2:
+            return unicode(self).encode('utf-8')
+        else:
+            return self.__unicode__()
+
+    def __unicode__(self):
         name = self.name
         ret = [u'BEGIN:' + name]
         for line in self:
             ret.append(six.text_type(line))
         ret.append(u'END:' + name)
-        if six.PY2:
-            return six.text_type(CRLF.join(ret)).encode('utf-8')
-        else:
-            return six.text_type(CRLF.join(ret))
+        return CRLF.join(ret)
 
     def __repr__(self):
         return "<Container '{}' with {} element{}>" \


### PR DESCRIPTION
After circleci tests failed, but I could manually export the ics files with non-latin letters, I realized that there was more byte/unicode issues. Lots of debugging later, I'm still not entirely sure about it (although pretty sure it's to do with python2 expecting bytes out of __str__).
I resorted to basing it on the previous iteration, outputting bytes from __str__ methods on python2.